### PR TITLE
stop linking to upstream release page

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,9 +42,7 @@ Features include:
 * Create backups locally to read offline or to your desired cloud service
 
 ## Download
-Get the app from our [releases page](https://github.com/tachiyomiorg/tachiyomi/releases).
-
-If you want to try new features before they get to the stable release, you can download the preview version [here](https://github.com/tachiyomiorg/tachiyomi-preview/releases).
+Get the app from our [releases page](https://github.com/Rattlehead15/tachiyomiOCR/releases).
 
 ## Issues, Feature Requests and Contributing
 


### PR DESCRIPTION
fixes https://github.com/Rattlehead15/tachiyomiOCR/issues/9