### PR TITLE
Adjust new Icons' Tint

### DIFF
--- a/app/src/main/res/menu/reader.xml
+++ b/app/src/main/res/menu/reader.xml
@@ -6,13 +6,13 @@
         android:id="@+id/action_dictionary"
         android:icon="@drawable/ic_translation"
         android:title="@string/action_dictionary"
-        app:iconTint="?attr/colorOnPrimary"
+        app:iconTint="?attr/colorOnToolbar"
         app:showAsAction="ifRoom" />
     <item
         android:id="@+id/action_ocr"
         android:icon="@drawable/ic_ocr"
         android:title="@string/action_ocr"
-        app:iconTint="?attr/colorOnPrimary"
+        app:iconTint="?attr/colorOnToolbar"
         app:showAsAction="ifRoom" />
 
     <item


### PR DESCRIPTION
Using the correct iconTint value to ensure visibility regardless of System UI colour scheme. Fixes #14 

Test build behaviour:

Light Mode 
![image](https://user-images.githubusercontent.com/16626553/147488314-13618e1d-b3cb-4046-b0fc-b82f93e2b178.png)

Dark Mode
![image](https://user-images.githubusercontent.com/16626553/147488331-ad626155-47ae-4d4e-9354-3cf2b63a815c.png)
